### PR TITLE
Dashboard: per-level stat cards, and in-DB flow filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Appropriately uses TAI time in https://github.com/punch-mission/punchpipe/pull/146
 * Stores quicklook movies in date-based file structure in https://github.com/punch-mission/punchpipe/pull/150
 * Checks that input files for quicklook movies are sorted and only schedules if files are found in https://github.com/punch-mission/punchpipe/pull/151
+* Improvements to dashboard status cards and flow table in https://github.com/punch-mission/punchpipe/pull/155
 
 ## Version 0.0.5: Jan 3, 2025
 

--- a/punchpipe/monitor/app.py
+++ b/punchpipe/monitor/app.py
@@ -147,9 +147,9 @@ def create_app():
                       "GROUP BY level;")
             l1plus_df = pd.read_sql_query(query, session.connection())
             # These states don't have a start_time set
-            query = (f"SELECT flow_level AS level, "
-                      "SUM(state = 'launched') AS n_launched, SUM(state = 'planned') AS n_planned "
-                     f"FROM flows GROUP BY level;")
+            query = ("SELECT flow_level AS level, "
+                     "SUM(state = 'launched') AS n_launched, SUM(state = 'planned') AS n_planned "
+                     "FROM flows GROUP BY level;")
             l1plus_second_df = pd.read_sql_query(query, session.connection())
             l1plus_df = l1plus_df.join(l1plus_second_df.set_index('level'), on='level')
             l1plus_df.fillna(0, inplace=True)


### PR DESCRIPTION
The cards look like this now;
![image](https://github.com/user-attachments/assets/30a43211-2aec-4ad8-b80e-1ecd72f6d6bc)

Also the flow table filtering and paginating all happens in the DB, so for a well-populated database it's much faster