### PR TITLE
If a file exists, do not try to recreate it.

### DIFF
--- a/punchpipe/control/processor.py
+++ b/punchpipe/control/processor.py
@@ -42,6 +42,8 @@ def generic_process_flow_logic(flow_id: int, core_flow_to_launch, pipeline_confi
         # update the file database entries as being created
         if file_db_entry_list:
             for file_db_entry in file_db_entry_list:
+                if file_db_entry.state == "created":
+                    raise RuntimeError(f"File id {file_db_entry.file_id} has already been created.")
                 file_db_entry.state = "creating"
         else:
             raise RuntimeError("There should be at least one file associated with this flow. Found 0.")


### PR DESCRIPTION
Check if the created state is already set. If so, throw an error. If not, proceed. 