### PR TITLE
Cleaner improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fixes metadata usage for quicklook animations in https://github.com/punch-mission/punchpipe/pull/185
 * Relabels CCD halves in https://github.com/punch-mission/punchpipe/pull/174
 * Don't remake existing files in https://github.com/punch-mission/punchpipe/pull/188
+* Clear .jp2, .sha, and parent directories in cleaner flow in https://github.com/punch-mission/punchpipe/pull/191
 
 ## Version 0.0.9: June 4, 2025
 

--- a/punchpipe/control/cleaner.py
+++ b/punchpipe/control/cleaner.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 from prefect import flow, get_run_logger
 
@@ -29,12 +30,27 @@ def cleaner(pipeline_config_path: str):
         parent.state = "created"
 
     logger.info(f"Deleting {len(children)} child files")
+    root_path = Path(pipeline_config["root"])
     for child in children:
-        output_path = os.path.join(
-            child.directory(pipeline_config["root"]), child.filename()
-        )
-        if os.path.exists(output_path):
+        output_path = Path(child.directory(pipeline_config["root"])) / child.filename()
+        if output_path.exists():
             os.remove(output_path)
+        sha_path = str(output_path) + '.sha'
+        if os.path.exists(sha_path):
+            os.remove(sha_path)
+        jp2_path = output_path.with_suffix('.jp2')
+        if jp2_path.exists():
+            os.remove(jp2_path)
+        # Iteratively remove parent directories if they're empty. output_path.parents gives the file's parent dir,
+        # then that dir's parent, then that dir's parent...
+        for parent_dir in output_path.parents:
+            if not parent_dir.exists():
+                break
+            if len(os.listdir(parent_dir)):
+                break
+            if parent_dir == root_path:
+                break
+            parent_dir.rmdir()
         session.delete(child)
 
     logger.info(f"Clearing {len(relationships)} file relationships")


### PR DESCRIPTION
Adds logging to `cleaner` flow, and in addition to deleting `.fits` files, deletes the corresponding `.sha` and `.jp2`, and also removes any directories left empty after file deletion.