### PR TITLE
Make mosaics with missing parts

### DIFF
--- a/punchpipe/flows/level2.py
+++ b/punchpipe/flows/level2.py
@@ -47,6 +47,7 @@ def level2_query_ready_files(session, pipeline_config: dict, reference_time=None
             grouped_files.append(all_ready_files[group_start:file_under_consideration])
             group_start = file_under_consideration
             tstamp_start = this_tstamp
+    grouped_files.append(all_ready_files[group_start:])
 
     logger.info(f"{len(grouped_files)} unique times")
     grouped_ready_files = []
@@ -93,6 +94,7 @@ def level2_query_ready_clear_files(session, pipeline_config: dict, reference_tim
             grouped_files.append(all_ready_files[group_start:file_under_consideration])
             group_start = file_under_consideration
             tstamp_start = this_tstamp
+    grouped_files.append(all_ready_files[group_start:])
 
     logger.info(f"{len(grouped_files)} unique times")
     grouped_ready_files = []

--- a/punchpipe/flows/levelq.py
+++ b/punchpipe/flows/levelq.py
@@ -152,6 +152,7 @@ def levelq_CTM_query_ready_files(session, pipeline_config: dict, reference_time=
             grouped_files.append(all_ready_files[group_start:file_under_consideration])
             group_start = file_under_consideration
             tstamp_start = this_tstamp
+    grouped_files.append(all_ready_files[group_start:])
 
     logger.info(f"{len(grouped_files)} unique times")
     grouped_ready_files = []

--- a/punchpipe/flows/levelq.py
+++ b/punchpipe/flows/levelq.py
@@ -155,10 +155,13 @@ def levelq_CTM_query_ready_files(session, pipeline_config: dict, reference_time=
 
     logger.info(f"{len(grouped_files)} unique times")
     grouped_ready_files = []
+    cutoff_time = pipeline_config["flows"]["levelq_CTM"].get("ignore_missing_after_days", None)
+    if cutoff_time is not None:
+        cutoff_time = datetime.now(tz=UTC) - timedelta(days=cutoff_time)
     for group in grouped_files:
         # TODO: We're excluding NFI for now
-        # if len(group) == 4:
-        if len(group) == 3:
+        # if len(group) == 4 or group[-1].date_obs.replace(tzinfo=UTC) < cutoff_time:
+        if len(group) == 3 or (cutoff_time and group[-1].date_obs.replace(tzinfo=UTC) < cutoff_time):
             grouped_ready_files.append([f.file_id for f in group])
         if len(grouped_ready_files) >= max_n:
             break

--- a/punchpipe/flows/tests/punchpipe_config.yaml
+++ b/punchpipe/flows/tests/punchpipe_config.yaml
@@ -59,8 +59,8 @@ flows:
     tags: ["L2"]
     options:
 
-  levelq:
-    description: "Creates Level Q files."
+  levelq_CTM:
+    description: "Creates Level Q CTM files."
     priority:
       initial: 1000
       seconds: [ 3000, 12000, 60000 ]

--- a/punchpipe/flows/tests/test_level2.py
+++ b/punchpipe/flows/tests/test_level2.py
@@ -13,6 +13,7 @@ from punchpipe.flows.level2 import (
     level2_construct_file_info,
     level2_construct_flow_info,
     level2_query_ready_files,
+    level2_query_ready_clear_files,
     level2_scheduler_flow,
 )
 
@@ -20,7 +21,7 @@ TEST_DIR = os.path.dirname(__file__)
 
 
 def session_fn(session):
-    level0_file = File(level=0,
+    level0_file = File(level='0',
                        file_type='XX',
                        observatory='0',
                        state='created',
@@ -28,16 +29,34 @@ def session_fn(session):
                        software_version='none',
                        date_obs=datetime(2023, 1, 1, 0, 0, 0))
 
-    level1_file = File(level=1,
-                       file_type="XX",
-                       observatory='0',
-                       state='created',
+    level1_file_not_ready = File(level='1',
+                                 file_type='PM',
+                                 observatory='4',
+                                 state='created',
+                                 file_version='none',
+                                 software_version='none',
+                                 date_obs=datetime(2023, 1, 1, 0, 0, 0))
+
+    level1_file = File(level='1',
+                       file_type='PM',
+                       observatory='4',
+                       state='quickpunched',
                        file_version='none',
                        software_version='none',
                        date_obs=datetime(2023, 1, 1, 0, 0, 0))
 
+    level1_file_clear = File(level='1',
+                             file_type='CR',
+                             observatory='4',
+                             state='quickpunched',
+                             file_version='none',
+                             software_version='none',
+                             date_obs=datetime(2023, 1, 1, 0, 0, 0))
+
     session.add(level0_file)
+    session.add(level1_file_not_ready)
     session.add(level1_file)
+    session.add(level1_file_clear)
 
 
 db = create_mysql_fixture(Base, session_fn, session=True)
@@ -46,10 +65,31 @@ db = create_mysql_fixture(Base, session_fn, session=True)
 def test_level2_query_ready_files(db):
     with disable_run_logger():
         with freeze_time(datetime(2023, 1, 1, 0, 5, 0)) as frozen_datatime:  # noqa: F841
-            pipeline_config = {'levels': {'level2_process_flow': {'schedule':
-                                                                      {'latency': 3, 'window_duration_seconds': 3}}}}
+            pipeline_config = {'flows': {'level2': {}}}
             ready_file_ids = level2_query_ready_files.fn(db, pipeline_config)
             assert len(ready_file_ids) == 0
+
+
+def test_level2_query_ready_files_ignore_missing(db):
+    with disable_run_logger():
+        with freeze_time(datetime(2023, 1, 2, 0, 0, 0, tzinfo=UTC)) as frozen_datatime:  # noqa: F841
+            pipeline_config = {'flows': {'level2': {'ignore_missing_after_days': 1.05}}}
+            ready_file_ids = level2_query_ready_files.fn(db, pipeline_config)
+            assert len(ready_file_ids) == 0
+            pipeline_config = {'flows': {'level2': {'ignore_missing_after_days': 0.95}}}
+            ready_file_ids = level2_query_ready_files.fn(db, pipeline_config)
+            assert len(ready_file_ids) == 1
+
+
+def test_level2_query_ready_files_ignore_missing_clear(db):
+    with disable_run_logger():
+        with freeze_time(datetime(2023, 1, 2, 0, 0, 0, tzinfo=UTC)) as frozen_datatime:  # noqa: F841
+            pipeline_config = {'flows': {'level2_clear': {'ignore_missing_after_days': 1.05}}}
+            ready_file_ids = level2_query_ready_clear_files.fn(db, pipeline_config)
+            assert len(ready_file_ids) == 0
+            pipeline_config = {'flows': {'level2_clear': {'ignore_missing_after_days': 0.95}}}
+            ready_file_ids = level2_query_ready_clear_files.fn(db, pipeline_config)
+            assert len(ready_file_ids) == 1
 
 
 def test_level2_construct_file_info():

--- a/punchpipe/flows/tests/test_levelQ.py
+++ b/punchpipe/flows/tests/test_levelQ.py
@@ -1,0 +1,109 @@
+import os
+from datetime import UTC, datetime
+
+from freezegun import freeze_time
+from prefect.logging import disable_run_logger
+from pytest_mock_resources import create_mysql_fixture
+
+from punchpipe import __version__
+from punchpipe.control.db import Base, File, Flow
+from punchpipe.control.util import load_pipeline_configuration
+from punchpipe.flows.levelq import (
+    levelq_CTM_construct_file_info,
+    levelq_CTM_construct_flow_info,
+    levelq_CTM_query_ready_files,
+)
+
+TEST_DIR = os.path.dirname(__file__)
+
+
+def session_fn(session):
+    level0_file = File(level="0",
+                       file_type="XX",
+                       observatory="0",
+                       state="created",
+                       file_version="none",
+                       software_version="none",
+                       date_obs=datetime(2023, 1, 1, 0, 0, 0))
+
+    level1_file_not_ready = File(level="1",
+                                 file_type="CR",
+                                 observatory="1",
+                                 state="planned",
+                                 file_version="none",
+                                 software_version="none",
+                                 date_obs=datetime(2023, 1, 1, 0, 0, 0))
+
+    level1_file = File(level="1",
+                       file_type="CR",
+                       observatory="1",
+                       state="created",
+                       file_version="none",
+                       software_version="none",
+                       date_obs=datetime(2023, 1, 1, 0, 0, 0))
+
+    session.add(level0_file)
+    session.add(level1_file_not_ready)
+    session.add(level1_file)
+
+
+db = create_mysql_fixture(Base, session_fn, session=True)
+
+
+def test_levelq_CTM_query_ready_files(db):
+    with disable_run_logger():
+        with freeze_time(datetime(2023, 1, 1, 0, 5, 0)) as frozen_datatime:  # noqa: F841
+            pipeline_config = {'flows': {'levelq_CTM': {}}}
+            ready_file_ids = levelq_CTM_query_ready_files.fn(db, pipeline_config)
+            assert len(ready_file_ids) == 0
+
+
+def test_levelq_CTM_query_ready_files_ignore_missing(db):
+    with disable_run_logger():
+        with freeze_time(datetime(2023, 1, 2, 0, 0, 0, tzinfo=UTC)) as frozen_datatime:  # noqa: F841
+            pipeline_config = {'flows': {'levelq_CTM': {'ignore_missing_after_days': 1.05}}}
+            ready_file_ids = levelq_CTM_query_ready_files.fn(db, pipeline_config)
+            assert len(ready_file_ids) == 0
+            pipeline_config = {'flows': {'levelq_CTM': {'ignore_missing_after_days': 0.95}}}
+            ready_file_ids = levelq_CTM_query_ready_files.fn(db, pipeline_config)
+            assert len(ready_file_ids) == 1
+
+
+def test_levelq_CTM_construct_file_info():
+    pipeline_config_path = os.path.join(TEST_DIR, "punchpipe_config.yaml")
+    pipeline_config = load_pipeline_configuration(pipeline_config_path)
+    level1_file = [File(level='1',
+                       file_type='CR',
+                       observatory='1',
+                       state='created',
+                       file_version='none',
+                       software_version='none',
+                       date_obs=datetime.now(UTC))]
+    constructed_file_info = levelq_CTM_construct_file_info.fn(level1_file, pipeline_config)[0]
+    assert constructed_file_info.level == "Q"
+    assert constructed_file_info.file_type == "CT"
+    assert constructed_file_info.observatory == "M"
+    assert constructed_file_info.file_version == "0.0.1"
+    assert constructed_file_info.software_version == __version__
+    assert constructed_file_info.date_obs == level1_file[0].date_obs
+    assert constructed_file_info.polarization is None
+    assert constructed_file_info.state == "planned"
+
+
+def test_levelq_CTM_construct_flow_info():
+    pipeline_config_path = os.path.join(TEST_DIR, "punchpipe_config.yaml")
+    pipeline_config = load_pipeline_configuration(pipeline_config_path)
+    level1_file = [File(level='1',
+                       file_type='CR',
+                       observatory='1',
+                       state='created',
+                       file_version='none',
+                       software_version='none',
+                       date_obs=datetime.now(UTC))]
+    levelQ_file = levelq_CTM_construct_file_info.fn(level1_file, pipeline_config)
+    flow_info = levelq_CTM_construct_flow_info.fn(level1_file, levelQ_file, pipeline_config)
+
+    assert flow_info.flow_type == 'levelq_CTM'
+    assert flow_info.state == "planned"
+    assert flow_info.flow_level == "Q"
+    assert flow_info.priority == 1000


### PR DESCRIPTION
In the config file, each flow section can have a `ignore_missing_after_days` key. If set, L2s and LQ CTMs will be made for groups older than that many days, even if some of the expected input files are missing.

Also fixes a bug that, when we're grouping up files by time, the last group was never actually added to the final list.

Adds a test, and also cleans up the L2 tests a bit and adds LQ CTM tests.