### PR TITLE
L2 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Clear .jp2, .sha, and parent directories in cleaner flow in https://github.com/punch-mission/punchpipe/pull/191
 * L2s and LQ CTMs with missing input files can be made anyway after a certain number of days in https://github.com/punch-mission/punchpipe/pull/194
 * Reduces L2 code duplication in https://github.com/punch-mission/punchpipe/pull/195
+* Set date_obs correctly in DB for L2s, and update cleaner flow for L2 in https://github.com/punch-mission/punchpipe/pull/196
 
 ## Version 0.0.9: June 4, 2025
 

--- a/punchpipe/control/cleaner.py
+++ b/punchpipe/control/cleaner.py
@@ -2,36 +2,47 @@ import os
 from pathlib import Path
 
 from prefect import flow, get_run_logger
+from sqlalchemy.orm import aliased
 
 from punchpipe.control.db import File, FileRelationship, Flow
 from punchpipe.control.util import get_database_session, load_pipeline_configuration
 
 
 @flow
-def cleaner(pipeline_config_path: str):
+def cleaner(pipeline_config_path: str, session=None):
     logger = get_run_logger()
 
     pipeline_config = load_pipeline_configuration(pipeline_config_path)
-    session = get_database_session()
+    if session is None:
+        session = get_database_session()
 
     # Note: I thought about adding a maximum here, but this flow takes only 5 seconds to revive 10,000 L1 flows, so I
     # think we're good.
-    flows = (session.query(Flow).where(Flow.state == 'revivable')
-                                .all())
-    flow_ids = [flow.flow_id for flow in flows]
-    children = session.query(File).where(File.processing_flow.in_(flow_ids)).all()
-    children_ids = [child.file_id for child in children]
-    parents = (session.query(File).join(FileRelationship, File.file_id == FileRelationship.parent)
-                      .where(FileRelationship.child.in_(children_ids)).all())
-    relationships = session.query(FileRelationship).where(FileRelationship.child.in_(children_ids)).all()
+    child = aliased(File)
+    parent = aliased(File)
+    results = (session.query(FileRelationship, parent, child, Flow)
+               .join(parent, parent.file_id == FileRelationship.parent)
+               .join(child, child.file_id == FileRelationship.child)
+               .join(Flow, Flow.flow_id == child.processing_flow)
+               .where(Flow.state == 'revivable')
+              ).all()
 
-    logger.info(f"Resetting {len(parents)} parent files")
-    for parent in parents:
-        parent.state = "created"
+    # This one loops differently than the others, because we need to track the child that's being deleted to know how
+    # to reset the parent.
+    unique_parents = set()
+    for _, parent, child, _ in results:
+        # Handle the case that both L2 and LQ have been set to 'revivable'. If the LQ shows up first in this loop and
+        # we set the L1's state to 'created', we don't want to later set it to 'quickpunched' when the L2 shows up.
+        if child.level == "2" and parent.state == "progressed":
+            parent.state = "quickpunched"
+        else:
+            parent.state = "created"
+        unique_parents.add(parent.file_id)
+    logger.info(f"Reset {len(unique_parents)} parent files")
 
-    logger.info(f"Deleting {len(children)} child files")
+    unique_children = {child for rel, parent, child, flow in results}
     root_path = Path(pipeline_config["root"])
-    for child in children:
+    for child in unique_children:
         output_path = Path(child.directory(pipeline_config["root"])) / child.filename()
         if output_path.exists():
             os.remove(output_path)
@@ -52,15 +63,18 @@ def cleaner(pipeline_config_path: str):
                 break
             parent_dir.rmdir()
         session.delete(child)
+    logger.info(f"Deleted {len(unique_children)} child files")
 
-    logger.info(f"Clearing {len(relationships)} file relationships")
-    for relationship in relationships:
+    # Every FileRelationship item is unique
+    for relationship, _, _, _ in results:
         session.delete(relationship)
+    logger.info(f"Cleared {len(results)} file relationships")
 
-    logger.info(f"Deleting {len(flows)} flows")
-    for f in flows:
+    unique_flows = {flow for rel, parent, child, flow in results}
+    for f in unique_flows:
         session.delete(f)
+    logger.info(f"Deleted {len(unique_flows)} flows")
 
     session.commit()
-    if len(flows):
-        logger.info(f"Revived {len(flows)} flows")
+    if len(unique_flows):
+        logger.info(f"Processed {len(unique_flows)} revivable flows")

--- a/punchpipe/control/db.py
+++ b/punchpipe/control/db.py
@@ -79,6 +79,9 @@ class Flow(Base):
     priority = Column(Integer, nullable=False)
     call_data = Column(TEXT, nullable=True)
 
+    def __repr__(self):
+        return f"Flow(id={self.flow_id!r})"
+
 
 class FileRelationship(Base):
     __tablename__ = "relationships"

--- a/punchpipe/control/tests/test_cleaner.py
+++ b/punchpipe/control/tests/test_cleaner.py
@@ -1,0 +1,319 @@
+from datetime import datetime, timedelta
+import os
+
+import pytest
+import yaml
+from prefect.logging import disable_run_logger
+from prefect.testing.utilities import prefect_test_harness
+from pytest_mock_resources import create_mysql_fixture
+
+from punchpipe.control.db import Base, File, FileRelationship, Flow
+from punchpipe.control.cleaner import cleaner
+from punchpipe.control.util import load_pipeline_configuration
+
+
+@pytest.fixture(autouse=True, scope="session")
+def prefect_test_fixture():
+    with prefect_test_harness():
+        yield
+
+
+def session_fn(session):
+    first_L1_flow = Flow(flow_level="1",
+                         flow_type="level1",
+                         state="completed",
+                         creation_time=datetime.now(),
+                         priority=1)
+
+    first_L1_flowA = Flow(flow_level="1",
+                          flow_type="level1",
+                          state="completed",
+                          creation_time=datetime.now(),
+                          priority=1)
+
+    first_LQ_flow = Flow(flow_level="Q",
+                         flow_type="levelQ",
+                         state="completed",
+                         creation_time=datetime.now(),
+                         priority=1)
+
+    first_L2_flow = Flow(flow_level="2",
+                         flow_type="level2",
+                         state="completed",
+                         creation_time=datetime.now(),
+                         priority=1)
+
+    second_L1_flow = Flow(flow_level="1",
+                          flow_type="level1",
+                          state="completed",
+                          creation_time=datetime.now(),
+                          priority=1)
+
+    second_LQ_flow = Flow(flow_level="Q",
+                          flow_type="levelQ",
+                          state="completed",
+                          creation_time=datetime.now(),
+                          priority=1)
+
+    session.add(first_L1_flow)
+    session.add(first_L1_flowA)
+    session.add(first_LQ_flow)
+    session.add(first_L2_flow)
+    session.add(second_L1_flow)
+    session.add(second_LQ_flow)
+    session.commit()
+
+    l0_file = File(level="0",
+                   file_type='PM',
+                   observatory='4',
+                   state='progressed',
+                   file_version='none',
+                   software_version='none',
+                   date_obs=datetime.now())
+
+    l1_file = File(level="1",
+                   file_type="PM",
+                   observatory='4',
+                   state='progressed',
+                   file_version='none',
+                   software_version='none',
+                   processing_flow=first_L1_flow.flow_id,
+                   date_obs=datetime.now())
+
+    l0_fileA = File(level="0",
+                    file_type='PM',
+                    observatory='3',
+                    state='progressed',
+                    file_version='none',
+                    software_version='none',
+                    date_obs=datetime.now())
+
+    l1_fileA = File(level="1",
+                    file_type="PM",
+                    observatory='3',
+                    state='progressed',
+                    file_version='none',
+                    software_version='none',
+                    processing_flow=first_L1_flowA.flow_id,
+                    date_obs=datetime.now())
+
+    lq_file = File(level="Q",
+                   file_type="PM",
+                   observatory='4',
+                   state='created',
+                   file_version='none',
+                   software_version='none',
+                   processing_flow=first_LQ_flow.flow_id,
+                   date_obs=datetime.now())
+
+    l2_file = File(level="2",
+                   file_type="PM",
+                   observatory='4',
+                   state='created',
+                   file_version='none',
+                   software_version='none',
+                   processing_flow=first_L2_flow.flow_id,
+                   date_obs=datetime.now())
+
+    second_l0_file = File(level="0",
+                          file_type='PM',
+                          observatory='4',
+                          state='progressed',
+                          file_version='none',
+                          software_version='none',
+                          date_obs=datetime.now() + timedelta(days=1))
+
+    second_l1_file = File(level="1",
+                          file_type="PM",
+                          observatory='4',
+                          state='quickpunched',
+                          file_version='none',
+                          software_version='none',
+                          processing_flow=second_L1_flow.flow_id,
+                          date_obs=datetime.now() + timedelta(days=1))
+
+    second_lq_file = File(level="Q",
+                          file_type="PM",
+                          observatory='4',
+                          state='created',
+                          file_version='none',
+                          software_version='none',
+                          processing_flow=second_LQ_flow.flow_id,
+                          date_obs=datetime.now() + timedelta(days=1))
+
+    session.add(l0_file)
+    session.add(l1_file)
+    session.add(l0_fileA)
+    session.add(l1_fileA)
+    session.add(lq_file)
+    session.add(l2_file)
+    session.add(second_l0_file)
+    session.add(second_l1_file)
+    session.add(second_lq_file)
+    session.commit()
+
+    session.add(FileRelationship(parent=l0_file.file_id, child=l1_file.file_id))
+    session.add(FileRelationship(parent=l0_fileA.file_id, child=l1_fileA.file_id))
+    session.add(FileRelationship(parent=l1_file.file_id, child=lq_file.file_id))
+    session.add(FileRelationship(parent=l1_fileA.file_id, child=lq_file.file_id))
+    session.add(FileRelationship(parent=l1_file.file_id, child=l2_file.file_id))
+    session.add(FileRelationship(parent=l1_fileA.file_id, child=l2_file.file_id))
+    session.add(FileRelationship(parent=second_l0_file.file_id, child=second_l1_file.file_id))
+    session.add(FileRelationship(parent=second_l1_file.file_id, child=second_lq_file.file_id))
+
+
+db = create_mysql_fixture(Base, session_fn, session=True)
+TEST_DIR = os.path.dirname(__file__)
+
+
+@pytest.fixture
+def populated_tmpdir_config(tmpdir, db):
+    files = db.query(File).all()
+    for file in files:
+        target = os.path.join(file.directory(tmpdir), file.filename())
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(target, 'w'):
+            pass
+        with open(target + '.sha', 'w'):
+            pass
+        with open(target.replace('.fits.', '.jp2'), 'w'):
+            pass
+    config = load_pipeline_configuration(os.path.join(TEST_DIR, "punchpipe_config.yaml"))
+    config['root'] = str(tmpdir)
+    new_config = os.path.join(tmpdir, 'config.yaml')
+    with open(new_config, 'w') as f:
+        yaml.dump(config, f)
+    return new_config
+
+
+def test_reset_L1(db, tmpdir, populated_tmpdir_config):
+    l1s = db.query(File).filter(File.level == "1").all()
+    reset_file = l1s[1]
+    reset_file_path = os.path.join(reset_file.directory(tmpdir), reset_file.filename())
+
+    reset_flow = db.query(Flow).filter(Flow.flow_id == reset_file.processing_flow).one()
+    reset_flow.state = 'revivable'
+    db.commit()
+
+    parent_file = (db.query(File)
+                     .join(FileRelationship, File.file_id == FileRelationship.parent)
+                     .filter(FileRelationship.child == reset_file.file_id)).one()
+    other_files = db.query(File).filter(File.file_id != reset_file.file_id).all()
+    other_flows = db.query(Flow).filter(Flow.flow_id != reset_flow.flow_id).all()
+
+    other_file_ids = [f.file_id for f in other_files]
+    other_flow_ids = [f.flow_id for f in other_flows]
+    other_file_paths = [os.path.join(f.directory(tmpdir), f.filename()) for f in other_files]
+
+    with disable_run_logger():
+        cleaner.fn(populated_tmpdir_config, session=db)
+
+    remaining_files = db.query(File).filter(File.file_id != reset_file.file_id).all()
+    remaining_flows = db.query(Flow).filter(Flow.flow_id != reset_flow.flow_id).all()
+
+    assert [f.file_id for f in remaining_files] == other_file_ids
+    assert [f.flow_id for f in remaining_flows] == other_flow_ids
+
+    for path in other_file_paths:
+        assert os.path.exists(path)
+    assert not os.path.exists(reset_file_path)
+    assert not os.path.exists(reset_file_path + '.sha')
+    assert not os.path.exists(reset_file_path.replace('.fits.', '.jp2'))
+    assert not os.path.exists(os.path.dirname(reset_file_path))
+
+    for file in remaining_files:
+        if file.file_id == parent_file.file_id:
+            assert file.state == 'created'
+
+    relationships = db.query(FileRelationship).filter(FileRelationship.child == reset_file.file_id).all()
+    assert len(relationships) == 0
+
+
+def test_reset_LQ(db, tmpdir, populated_tmpdir_config):
+    lqs = db.query(File).filter(File.level == "Q").all()
+    reset_file = lqs[0]
+    reset_file_path = os.path.join(reset_file.directory(tmpdir), reset_file.filename())
+
+    reset_flow = db.query(Flow).filter(Flow.flow_id == reset_file.processing_flow).one()
+    reset_flow.state = 'revivable'
+    db.commit()
+
+    parent_files = (db.query(File)
+                      .join(FileRelationship, File.file_id == FileRelationship.parent)
+                      .filter(FileRelationship.child == reset_file.file_id)).all()
+    parent_file_ids = [f.file_id for f in parent_files]
+    assert len(parent_file_ids) == 2
+    other_files = db.query(File).filter(File.file_id != reset_file.file_id).all()
+    other_flows = db.query(Flow).filter(Flow.flow_id != reset_flow.flow_id).all()
+
+    other_file_ids = [f.file_id for f in other_files]
+    other_flow_ids = [f.flow_id for f in other_flows]
+    other_file_paths = [os.path.join(f.directory(tmpdir), f.filename()) for f in other_files]
+
+    with disable_run_logger():
+        cleaner.fn(populated_tmpdir_config, session=db)
+
+    remaining_files = db.query(File).filter(File.file_id != reset_file.file_id).all()
+    remaining_flows = db.query(Flow).filter(Flow.flow_id != reset_flow.flow_id).all()
+
+    assert [f.file_id for f in remaining_files] == other_file_ids
+    assert [f.flow_id for f in remaining_flows] == other_flow_ids
+
+    for path in other_file_paths:
+        assert os.path.exists(path)
+    assert not os.path.exists(reset_file_path)
+    assert not os.path.exists(reset_file_path + '.sha')
+    assert not os.path.exists(reset_file_path.replace('.fits.', '.jp2'))
+    assert not os.path.exists(os.path.dirname(reset_file_path))
+
+    for file in remaining_files:
+        if file.file_id in parent_file_ids:
+            assert file.state == 'created'
+
+    relationships = db.query(FileRelationship).filter(FileRelationship.child == reset_file.file_id).all()
+    assert len(relationships) == 0
+
+
+def test_reset_L2(db, tmpdir, populated_tmpdir_config):
+    l2s = db.query(File).filter(File.level == "2").all()
+    reset_file = l2s[0]
+    reset_file_path = os.path.join(reset_file.directory(tmpdir), reset_file.filename())
+
+    reset_flow = db.query(Flow).filter(Flow.flow_id == reset_file.processing_flow).one()
+    reset_flow.state = 'revivable'
+    db.commit()
+
+    parent_files = (db.query(File)
+                      .join(FileRelationship, File.file_id == FileRelationship.parent)
+                      .filter(FileRelationship.child == reset_file.file_id)).all()
+    parent_file_ids = [f.file_id for f in parent_files]
+    assert len(parent_file_ids) == 2
+    other_files = db.query(File).filter(File.file_id != reset_file.file_id).all()
+    other_flows = db.query(Flow).filter(Flow.flow_id != reset_flow.flow_id).all()
+
+    other_file_ids = [f.file_id for f in other_files]
+    other_flow_ids = [f.flow_id for f in other_flows]
+    other_file_paths = [os.path.join(f.directory(tmpdir), f.filename()) for f in other_files]
+
+    with disable_run_logger():
+        cleaner.fn(populated_tmpdir_config, session=db)
+
+    remaining_files = db.query(File).filter(File.file_id != reset_file.file_id).all()
+    remaining_flows = db.query(Flow).filter(Flow.flow_id != reset_flow.flow_id).all()
+
+    assert [f.file_id for f in remaining_files] == other_file_ids
+    assert [f.flow_id for f in remaining_flows] == other_flow_ids
+
+    for path in other_file_paths:
+        assert os.path.exists(path)
+    assert not os.path.exists(reset_file_path)
+    assert not os.path.exists(reset_file_path + '.sha')
+    assert not os.path.exists(reset_file_path.replace('.fits.', '.jp2'))
+    assert not os.path.exists(os.path.dirname(reset_file_path))
+
+    for file in remaining_files:
+        if file.file_id in parent_file_ids:
+            assert file.state == 'quickpunched'
+
+    relationships = db.query(FileRelationship).filter(FileRelationship.child == reset_file.file_id).all()
+    assert len(relationships) == 0

--- a/punchpipe/flows/level2.py
+++ b/punchpipe/flows/level2.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime, timedelta
 from prefect import flow, get_run_logger, task
 from prefect.cache_policies import NO_CACHE
 from punchbowl.level2.flow import level2_core_flow
+from punchbowl.util import average_datetime
 
 from punchpipe import __version__
 from punchpipe.control.db import File, Flow
@@ -108,7 +109,7 @@ def level2_construct_file_info(level1_files: t.List[File], pipeline_config: dict
                 observatory="M",
                 file_version=pipeline_config["file_version"],
                 software_version=__version__,
-                date_obs=level1_files[0].date_obs,
+                date_obs=average_datetime([f.date_obs for f in level1_files]),
                 state="planned",
             )]
 


### PR DESCRIPTION
`date_obs` has to be set correctly in the DB.

The `cleaner` flow was re-worked, to allow special-casing the resetting of L2s (the L1 parent files have to have their state set to `quickpunched`, not `created`)