### PR TITLE
Dashboard fix for cards with multiple file types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 [This is available in GitHub](https://github.com/punch-mission/punchpipe/releases)
 
+## Unreleased
+* Dashboard fix for file cards with multiple file types in https://github.com/punch-mission/punchpipe/pull/202
+
 ## Version 0.0.10: July 3, 2025
 
 * Fixes metadata usage for quicklook animations in https://github.com/punch-mission/punchpipe/pull/185

--- a/punchpipe/monitor/app.py
+++ b/punchpipe/monitor/app.py
@@ -236,9 +236,9 @@ def create_app():
                                               color="light", inverse=False)))
                 continue
 
-            n_created, n_failed = sub_df['n_created'].iloc[0], sub_df['n_failed'].iloc[0]
-            n_creating, n_progressed = sub_df['n_creating'].iloc[0], sub_df['n_progressed'].iloc[0]
-            n_quickpunched, n_planned = sub_df['n_quickpunched'].iloc[0], sub_df['n_planned'].iloc[0]
+            n_created, n_failed = sub_df['n_created'].sum(), sub_df['n_failed'].sum()
+            n_creating, n_progressed = sub_df['n_creating'].sum(), sub_df['n_progressed'].sum()
+            n_quickpunched, n_planned = sub_df['n_quickpunched'].sum(), sub_df['n_planned'].sum()
 
             n_good = n_created + n_quickpunched + n_progressed
 


### PR DESCRIPTION
For, e.g., the L1 Files card on the dashboard, we need to add across all file types, not pick the first one.