### PR TITLE
Tweak stray light scheduling priority

### DIFF
--- a/punchpipe/control/processor.py
+++ b/punchpipe/control/processor.py
@@ -1,5 +1,5 @@
-import json
 import os
+import json
 from datetime import datetime
 
 from prefect import get_run_logger, tags

--- a/punchpipe/control/processor.py
+++ b/punchpipe/control/processor.py
@@ -1,8 +1,8 @@
-import os
 import json
+import os
 from datetime import datetime
 
-from prefect import get_run_logger
+from prefect import get_run_logger, tags
 from prefect.context import get_run_context
 
 from punchpipe.control.db import File, Flow
@@ -64,7 +64,9 @@ def generic_process_flow_logic(flow_id: int, core_flow_to_launch, pipeline_confi
         expected_file_ids = {entry.file_id for entry in file_db_entry_list}
         logger.info(f"Expecting to output files with ids={expected_file_ids}.")
 
-        results = core_flow_to_launch(**flow_call_data)
+        tag_set = {entry.file_type + entry.observatory for entry in file_db_entry_list}
+        with tags(*tag_set):
+            results = core_flow_to_launch(**flow_call_data)
         for result in results:
             result.meta['FILEVRSN'] = pipeline_config["file_version"]
             file_db_entry = match_data_with_file_db_entry(result, file_db_entry_list)

--- a/punchpipe/flows/tests/test_level2.py
+++ b/punchpipe/flows/tests/test_level2.py
@@ -1,5 +1,5 @@
-import os
 import itertools
+import os
 from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
@@ -9,7 +9,7 @@ from pytest_mock_resources import create_mysql_fixture
 
 from punchpipe import __version__
 from punchpipe.control.db import Base, File, Flow
-from punchpipe.control.util import load_pipeline_configuration
+from punchpipe.control.util import load_pipeline_configuration, batched
 from punchpipe.flows.level2 import (
     group_l2_inputs,
     group_l2_inputs_single_observatory,
@@ -128,7 +128,7 @@ def test_level2_query_ready_files():
                 input_files = []
                 expected_groups = [[], [], []]
                 expected_output_group = 0
-                for triplet, is_complete in zip(itertools.batched(wfi1 + wfi2 + wfi3 + nfi, 3), groups_are_complete):
+                for triplet, is_complete in zip(batched(wfi1 + wfi2 + wfi3 + nfi, 3), groups_are_complete):
                     # We're iterating through the triplets sorted first by observatory, then by time.
                     if not is_complete:
                         # This triplet should be missing a file

--- a/punchpipe/flows/tests/test_level2.py
+++ b/punchpipe/flows/tests/test_level2.py
@@ -1,5 +1,5 @@
-import itertools
 import os
+import itertools
 from datetime import UTC, datetime, timedelta
 
 from freezegun import freeze_time
@@ -9,7 +9,7 @@ from pytest_mock_resources import create_mysql_fixture
 
 from punchpipe import __version__
 from punchpipe.control.db import Base, File, Flow
-from punchpipe.control.util import load_pipeline_configuration, batched
+from punchpipe.control.util import batched, load_pipeline_configuration
 from punchpipe.flows.level2 import (
     group_l2_inputs,
     group_l2_inputs_single_observatory,


### PR DESCRIPTION
* Work backwards in time to schedule stray light models, so the stuff useful to QuickPUNCH happens first
* A little more logging
* Tag inner flows with output file types
* Have the reset script clear and planned stray light model flows if we're resetting their input files
* Fix tests on Python 3.11