### PR TITLE
Fix LQ CNN scheduling, set stray light polarization in DB, and cap stray light generation thread count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Tweaks to stray light models scheduling in https://github.com/punch-mission/punchpipe/pull/237
 * Tagging of flows with output file types in https://github.com/punch-mission/punchpipe/pull/237 and https://github.com/punch-mission/punchpipe/pull/238
 * Set L0 polarization state in database in https://github.com/punch-mission/punchpipe/pull/239
+* Fix LQ CNN scheduling and cap stray light generation thread count in https://github.com/punch-mission/punchpipe/pull/240
 
 ## Version 0.0.12: August 6, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Tweaks to stray light models scheduling in https://github.com/punch-mission/punchpipe/pull/237
 * Tagging of flows with output file types in https://github.com/punch-mission/punchpipe/pull/237 and https://github.com/punch-mission/punchpipe/pull/238
 * Set L0 polarization state in database in https://github.com/punch-mission/punchpipe/pull/239
-* Fix LQ CNN scheduling and cap stray light generation thread count in https://github.com/punch-mission/punchpipe/pull/240
+* Fix LQ CNN scheduling, set stray light polarization in DB, and cap stray light generation thread count in https://github.com/punch-mission/punchpipe/pull/240
 
 ## Version 0.0.12: August 6, 2025
 

--- a/punchpipe/flows/levelq.py
+++ b/punchpipe/flows/levelq.py
@@ -33,7 +33,7 @@ def levelq_CNN_query_ready_files(session, pipeline_config: dict, reference_time=
     all_fittable_files = (session.query(File).filter(File.state.in_(("created", "progressed")))
                           .filter(File.level == "1")
                           .filter(File.observatory == "4")
-                          .filter(File.file_type == "CR").limit(1000).all())
+                          .filter(File.file_type == "QR").limit(1000).all())
     if len(all_fittable_files) < 1000:
         logger.info("Not enough fittable files")
         return []

--- a/punchpipe/flows/stray_light.py
+++ b/punchpipe/flows/stray_light.py
@@ -205,6 +205,7 @@ def construct_stray_light_scheduler_flow(pipeline_config_path=None, session=None
 def construct_stray_light_call_data_processor(call_data: dict, pipeline_config, session) -> dict:
     # Prepend the directory path to each input file
     call_data['filepaths'] = file_name_to_full_path(call_data['filepaths'], pipeline_config['root'])
+    call_data['num_workers'] = 32
     return call_data
 
 @flow

--- a/punchpipe/flows/stray_light.py
+++ b/punchpipe/flows/stray_light.py
@@ -120,6 +120,7 @@ def construct_stray_light_file_info(level1_files: t.List[File],
                 date_obs=reference_time,
                 date_beg=min(date_obses),
                 date_end=max(date_obses),
+                polarization=level1_files[0].polarization,
                 state="planned",
             ),]
 


### PR DESCRIPTION
Three quick changes:

* Cap the number of threads for stray light generation
* Quick fix to LQ CNN scheduling
* Set stray light model polarization in database