### PR TITLE
Misc pipeline fixes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Tagging of flows with output file types in https://github.com/punch-mission/punchpipe/pull/237 and https://github.com/punch-mission/punchpipe/pull/238
 * Set L0 polarization state in database in https://github.com/punch-mission/punchpipe/pull/239
 * Fix LQ CNN scheduling, set stray light polarization in DB, and cap stray light generation thread count in https://github.com/punch-mission/punchpipe/pull/240
+* Misc pipeline optimizations and fixes in https://github.com/punch-mission/punchpipe/pull/243
 
 ## Version 0.0.12: August 6, 2025
 

--- a/punchpipe/cli.py
+++ b/punchpipe/cli.py
@@ -196,17 +196,17 @@ def run(configuration_path, launch_prefect=False):
                 if launch_prefect:
                     prefect_process.poll()
                     prefect_services_process.poll()
-                    if prefect_process.returncode or prefect_services_process.returncode:
+                    if prefect_process.returncode is not None or prefect_services_process.returncode is not None:
                         print("Prefect process exited unexpectedly")
                         break
-                if cluster_process.returncode:
+                if cluster_process.returncode is not None:
                     print("Cluster process exited unexpectedly")
                     break
                 # Core processes are still running. Now check worker processes, which we can restart safely
-                if control_process.returncode:
+                if control_process.returncode is not None:
                     print(f"Restarted control process at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
                     control_process = control_process_launcher()
-                if data_process.returncode:
+                if data_process.returncode is not None:
                     print(f"Restarted data process at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
                     data_process = data_process_launcher()
                 time.sleep(10)

--- a/punchpipe/cli.py
+++ b/punchpipe/cli.py
@@ -31,12 +31,13 @@ def main():
 
     run_parser.add_argument("config", type=str, help="Path to config.")
     run_parser.add_argument("--launch-prefect", action="store_true", help="Launch the prefect server")
+    run_parser.add_argument("--no-dask-cluster", action="store_true", help="Skip launching the dask cluster")
     serve_control_parser.add_argument("config", type=str, help="Path to config.")
     serve_data_parser.add_argument("config", type=str, help="Path to config.")
     args = parser.parse_args()
 
     if args.command == 'run':
-        run(args.config, args.launch_prefect)
+        run(args.config, args.launch_prefect, not args.no_dask_cluster)
     elif args.command == 'serve-data':
         run_data(args.config)
     elif args.command == 'serve-control':
@@ -128,7 +129,7 @@ def run_control(configuration_path):
     configuration_path = str(Path(configuration_path).resolve())
     serve(*construct_flows_to_serve(configuration_path, include_control=True, include_data=False))
 
-def run(configuration_path, launch_prefect=False):
+def run(configuration_path, launch_prefect=False, launch_dask_cluster=False):
     now = datetime.now()
 
     configuration_path = str(Path(configuration_path).resolve())
@@ -159,8 +160,9 @@ def run(configuration_path, launch_prefect=False):
                 prefect_services_process = subprocess.Popen(
                     [*numa_prefix_control, "prefect", "server", "services", "start"], stdout=f, stderr=f)
 
-            cluster_process = subprocess.Popen([*numa_prefix_workers, 'punchpipe_cluster', configuration_path],
-                                               stdout=f, stderr=f)
+            if launch_dask_cluster:
+                cluster_process = subprocess.Popen([*numa_prefix_workers, 'punchpipe_cluster', configuration_path],
+                                                   stdout=f, stderr=f)
             monitor_process = subprocess.Popen([*numa_prefix_control, "gunicorn",
                                                 "-b", "0.0.0.0:8050",
                                                 "--chdir", THIS_DIR,
@@ -190,7 +192,8 @@ def run(configuration_path, launch_prefect=False):
             time.sleep(10)
             while True:
                 # `.poll()` updates but does not return the object's returncode attribute
-                cluster_process.poll()
+                if cluster_process is not None:
+                    cluster_process.poll()
                 control_process.poll()
                 data_process.poll()
                 if launch_prefect:
@@ -199,7 +202,7 @@ def run(configuration_path, launch_prefect=False):
                     if prefect_process.returncode is not None or prefect_services_process.returncode is not None:
                         print("Prefect process exited unexpectedly")
                         break
-                if cluster_process.returncode is not None:
+                if cluster_process is not None and cluster_process.returncode is not None:
                     print("Cluster process exited unexpectedly")
                     break
                 # Core processes are still running. Now check worker processes, which we can restart safely

--- a/punchpipe/cluster.py
+++ b/punchpipe/cluster.py
@@ -28,6 +28,9 @@ def main():
     try:
         while True:
             time.sleep(5)
+            if not os.path.exists(configuration_path):
+                # In case the file is being re-written right now. (This has happened and crashed this process!)
+                time.sleep(1)
             if (cur_mtime := os.path.getmtime(configuration_path)) != config_mtime:
                 config_mtime = cur_mtime
                 config = load_pipeline_configuration(configuration_path)

--- a/punchpipe/control/launcher.py
+++ b/punchpipe/control/launcher.py
@@ -156,7 +156,8 @@ async def launch_ready_flows(session: Session, flow_ids: List[int], tags_by_flow
             delay_time = total_delay_time / (n_batches - 1)
         awaitables = []
         responses = []
-        for batch in batched(flow_info, batch_size):
+        all_batches = list(batched(flow_info, batch_size))
+        for batch_number, batch in enumerate(all_batches):
             start = datetime.now().timestamp()
 
             for flow in batch:
@@ -174,7 +175,7 @@ async def launch_ready_flows(session: Session, flow_ids: List[int], tags_by_flow
 
             responses.extend(await asyncio.gather(*awaitables))
             awaitables = []
-            logger.info(f"Batch of {len(batch)} sent")
+            logger.info(f"Batch {batch_number}/{len(all_batches)} sent, containing {len(batch)} flows")
             if delay_time:
                 # Stagger the launches
                 await asyncio.sleep(delay_time - (datetime.now().timestamp() - start))

--- a/punchpipe/control/processor.py
+++ b/punchpipe/control/processor.py
@@ -75,9 +75,9 @@ def generic_process_flow_logic(flow_id: int, core_flow_to_launch, pipeline_confi
             filename = write_file(result, file_db_entry, pipeline_config)
             logger.info(f"Wrote to {filename}")
 
-        for file_id in expected_file_ids.difference(output_file_ids):
-            entry = session.query(File).where(File.file_id == file_id).one()
-            entry.state = "unreported"
+        missing_file_ids = expected_file_ids.difference(output_file_ids)
+        if missing_file_ids:
+            raise RuntimeError(f"We did not get an output cube for file ids {missing_file_ids}")
 
         session.commit()
 

--- a/punchpipe/control/scheduler.py
+++ b/punchpipe/control/scheduler.py
@@ -110,7 +110,6 @@ def generic_scheduler_flow_logic(
             # set the processing flow now that we know the flow_id after committing the flow info
             for child_file in children_files:
                 child_file.processing_flow = database_flow_info.flow_id
-            session.commit()
 
             # create a file relationship between the prior and next levels
             if children_are_one_to_one:
@@ -119,5 +118,5 @@ def generic_scheduler_flow_logic(
                 iterable = itertools.product(parent_files, children_files)
             for parent_file, child_file in iterable:
                 session.add(FileRelationship(parent=parent_file.file_id, child=child_file.file_id))
-            session.commit()
+        session.commit()
     return len(ready_file_ids)

--- a/punchpipe/control/tests/test_processor.py
+++ b/punchpipe/control/tests/test_processor.py
@@ -174,12 +174,8 @@ def test_simple_generic_process_flow_unreported(db):
     flow.state = 'launched'
     db.commit()
     del flow
-    with prefect_test_harness():
+    with prefect_test_harness(), pytest.raises(RuntimeError, match=".*We did not get an output cube.*"):
         empty_flow(1, session=db)
-
-    level1_file = db.query(File).where(File.file_id == 2).one()
-    assert level1_file.state == "unreported"
-    del level1_file
 
 
 @flow


### PR DESCRIPTION
Here's a batch of stand-alone changes.

A while back I added logic that attempts to re-start the processes serving the flows if they crash. That clearly wasn't working, and I think it's because those processes were catching the exceptions and ending with a return code of 0. Now this just checks for any return code, indicating the processes is no longer running.

I had one pipeline crash on 190 because the dask cluster tried to reload the config file at what appeared to be the exact instant I was saving the config file. This tries to handle that, and also adds a `cli` flag to just not launch the dask cluster, since it's only used for simpunch.

It's tempting to launch a ton of instances of really short-lived flows, but too many at once can overwhelm Prefect and/or the databases. Rather than having to set those flows' weights higher to avoid running too many at once, this adds a "max number of flows to launch" config, in addition to the "max weight" values. This lets us cap the number of launched flows, for the DBs' sake, while keeping the launch weights representative of the CPU cycles a flow will need.