### PR TITLE
Make sure date_obs in the DB exactly matches what's in the file

### DIFF
--- a/punchpipe/control/processor.py
+++ b/punchpipe/control/processor.py
@@ -82,6 +82,7 @@ def generic_process_flow_logic(flow_id: int | list[int], core_flow_to_launch, pi
                 file_db_entry = match_data_with_file_db_entry(result, file_db_entry_list)
                 logger.info(f"Preparing to write {file_db_entry.file_id}.")
                 output_file_ids.add(file_db_entry.file_id)
+                file_db_entry.date_obs = result.meta['DATE-OBS'].value
                 result.meta['OUTLIER'] = int(file_db_entry.outlier)
                 filename = write_file(result, file_db_entry, pipeline_config)
                 logger.info(f"Wrote to {filename}")


### PR DESCRIPTION
Importing L3 files into the DB on phoenix didn't set all the corresponding L2s to 'progressed', because the L2s have DATE-OBS in their headers set to three decimal places, but date_obs in the database is set to six decimal places. Why not just make sure the DB value gets set to the file value when we write it out?